### PR TITLE
Add alternate non-rc constructor for AnalysisContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ $ cargo add golem-wasm-ast
 Then parse a WASM module or component from an array of bytes:
 
 ```rust
-use mappable_rc::Mrc;
 use std::fmt::Debug;
 use golem_wasm_ast::DefaultAst;
 use golem_wasm_ast::analysis::AnalysisContext;
@@ -33,7 +32,7 @@ fn main() {
 
     println!("component metadata {:?}", component.get_metadata());
 
-    let state = AnalysisContext::new(Mrc::new(component));
+    let state = AnalysisContext::new(component);
     let analysed_exports = state.get_top_level_exports().unwrap();
     println!("analysed exports: {:?}", analysed_exports);
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # golem-wasm-ast
+<p>
+    <a href="https://crates.io/crates/golem-wasm-ast">
+        <img src="https://img.shields.io/crates/v/golem-wasm-ast.svg" alt="Crate"/>
+    </a>
+    <a href="https://docs.rs/golem-wasm-ast/latest/">
+        <img src="https://docs.rs/golem-wasm-ast/badge.svg" alt="Docs"/>
+    </a>
+</p>
+
 Higher level WASM library for Rust
 
 This library defines an in-memory, mutable representation of WebAssembly modules and [components](https://github.com/WebAssembly/component-model). It uses  

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -121,8 +121,12 @@ pub struct AnalysisContext<Ast: AstCustomization + 'static> {
 }
 
 impl<Ast: AstCustomization + 'static> AnalysisContext<Ast> {
+    pub fn new(component: Component<Ast>) -> AnalysisContext<Ast> {
+        AnalysisContext::from_rc(Mrc::new(component))
+    }
+
     /// Initializes an analyzer for a given component
-    pub fn new(component: Mrc<Component<Ast>>) -> AnalysisContext<Ast> {
+    pub fn from_rc(component: Mrc<Component<Ast>>) -> AnalysisContext<Ast> {
         AnalysisContext {
             component_stack: vec![component],
             warnings: RefCell::new(Vec::new()),


### PR DESCRIPTION
Prevents users from having to add `Mrc` crate