### PR TITLE
Constructor functions for AnalysedType

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -691,10 +691,10 @@ impl<Ast: AstCustomization + 'static> AnalysisContext<Ast> {
 
 #[cfg(test)]
 mod tests {
+    use crate::analysis::analysed_type::{f32, field, handle, record, result, str, u32, u64};
     use crate::analysis::{
         AnalysedFunction, AnalysedFunctionParameter, AnalysedFunctionResult, AnalysedResourceId,
-        AnalysedResourceMode, AnalysedType, NameTypePair, TypeF32, TypeHandle, TypeRecord,
-        TypeResult, TypeStr, TypeU32, TypeU64,
+        AnalysedResourceMode,
     };
 
     #[test]
@@ -703,14 +703,11 @@ mod tests {
             name: "[constructor]cart".to_string(),
             parameters: vec![AnalysedFunctionParameter {
                 name: "user-id".to_string(),
-                typ: AnalysedType::Str(TypeStr),
+                typ: str(),
             }],
             results: vec![AnalysedFunctionResult {
                 name: None,
-                typ: AnalysedType::Handle(TypeHandle {
-                    resource_id: AnalysedResourceId(0),
-                    mode: AnalysedResourceMode::Owned,
-                }),
+                typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Owned),
             }],
         };
         let method = AnalysedFunction {
@@ -718,33 +715,16 @@ mod tests {
             parameters: vec![
                 AnalysedFunctionParameter {
                     name: "self".to_string(),
-                    typ: AnalysedType::Handle(TypeHandle {
-                        resource_id: AnalysedResourceId(0),
-                        mode: AnalysedResourceMode::Borrowed,
-                    }),
+                    typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                 },
                 AnalysedFunctionParameter {
                     name: "item".to_string(),
-                    typ: AnalysedType::Record(TypeRecord {
-                        fields: vec![
-                            NameTypePair {
-                                name: "product-id".to_string(),
-                                typ: AnalysedType::Str(TypeStr),
-                            },
-                            NameTypePair {
-                                name: "name".to_string(),
-                                typ: AnalysedType::Str(TypeStr),
-                            },
-                            NameTypePair {
-                                name: "price".to_string(),
-                                typ: AnalysedType::F32(TypeF32),
-                            },
-                            NameTypePair {
-                                name: "quantity".to_string(),
-                                typ: AnalysedType::U32(TypeU32),
-                            },
-                        ],
-                    }),
+                    typ: record(vec![
+                        field("product-id", str()),
+                        field("name", str()),
+                        field("price", f32()),
+                        field("quantity", u32()),
+                    ]),
                 },
             ],
             results: vec![],
@@ -754,50 +734,30 @@ mod tests {
             parameters: vec![
                 AnalysedFunctionParameter {
                     name: "self".to_string(),
-                    typ: AnalysedType::Handle(TypeHandle {
-                        resource_id: AnalysedResourceId(0),
-                        mode: AnalysedResourceMode::Borrowed,
-                    }),
+                    typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                 },
                 AnalysedFunctionParameter {
                     name: "that".to_string(),
-                    typ: AnalysedType::Handle(TypeHandle {
-                        resource_id: AnalysedResourceId(0),
-                        mode: AnalysedResourceMode::Borrowed,
-                    }),
+                    typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                 },
             ],
             results: vec![AnalysedFunctionResult {
                 name: None,
-                typ: AnalysedType::Handle(TypeHandle {
-                    resource_id: AnalysedResourceId(0),
-                    mode: AnalysedResourceMode::Owned,
-                }),
+                typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Owned),
             }],
         };
         let fun = AnalysedFunction {
             name: "hash".to_string(),
             parameters: vec![AnalysedFunctionParameter {
                 name: "path".to_string(),
-                typ: AnalysedType::Str(TypeStr),
+                typ: str(),
             }],
             results: vec![AnalysedFunctionResult {
                 name: None,
-                typ: AnalysedType::Result(TypeResult {
-                    ok: Some(Box::new(AnalysedType::Record(TypeRecord {
-                        fields: vec![
-                            NameTypePair {
-                                name: "lower".to_string(),
-                                typ: AnalysedType::U64(TypeU64),
-                            },
-                            NameTypePair {
-                                name: "upper".to_string(),
-                                typ: AnalysedType::U64(TypeU64),
-                            },
-                        ],
-                    }))),
-                    err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                }),
+                typ: result(
+                    record(vec![field("lower", u64()), field("upper", u64())]),
+                    str(),
+                ),
             }],
         };
 

--- a/src/analysis/model.rs
+++ b/src/analysis/model.rs
@@ -281,7 +281,9 @@ pub enum AnalysedType {
     Handle(TypeHandle),
 }
 
-impl AnalysedType {
+pub mod analysed_type {
+    use crate::analysis::*;
+
     pub fn field(name: &str, typ: AnalysedType) -> NameTypePair {
         NameTypePair {
             name: name.to_string(),

--- a/src/analysis/model.rs
+++ b/src/analysis/model.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::analysis::analysed_type::{
+    bool, chr, f32, f64, s16, s32, s64, s8, str, u16, u32, u64, u8,
+};
 use crate::analysis::AnalysisResult;
 use crate::component::{ComponentExternalKind, PrimitiveValueType};
 
@@ -413,6 +416,10 @@ pub mod analysed_type {
     pub fn variant(cases: Vec<NameOptionTypePair>) -> AnalysedType {
         AnalysedType::Variant(TypeVariant { cases })
     }
+
+    pub fn handle(resource_id: AnalysedResourceId, mode: AnalysedResourceMode) -> AnalysedType {
+        AnalysedType::Handle(TypeHandle { resource_id, mode })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
@@ -433,19 +440,19 @@ pub struct AnalysedResourceId(pub u64);
 impl From<&PrimitiveValueType> for AnalysedType {
     fn from(value: &PrimitiveValueType) -> Self {
         match value {
-            PrimitiveValueType::Bool => AnalysedType::Bool(TypeBool),
-            PrimitiveValueType::S8 => AnalysedType::S8(TypeS8),
-            PrimitiveValueType::U8 => AnalysedType::U8(TypeU8),
-            PrimitiveValueType::S16 => AnalysedType::S16(TypeS16),
-            PrimitiveValueType::U16 => AnalysedType::U16(TypeU16),
-            PrimitiveValueType::S32 => AnalysedType::S32(TypeS32),
-            PrimitiveValueType::U32 => AnalysedType::U32(TypeU32),
-            PrimitiveValueType::S64 => AnalysedType::S64(TypeS64),
-            PrimitiveValueType::U64 => AnalysedType::U64(TypeU64),
-            PrimitiveValueType::F32 => AnalysedType::F32(TypeF32),
-            PrimitiveValueType::F64 => AnalysedType::F64(TypeF64),
-            PrimitiveValueType::Chr => AnalysedType::Chr(TypeChr),
-            PrimitiveValueType::Str => AnalysedType::Str(TypeStr),
+            PrimitiveValueType::Bool => bool(),
+            PrimitiveValueType::S8 => s8(),
+            PrimitiveValueType::U8 => u8(),
+            PrimitiveValueType::S16 => s16(),
+            PrimitiveValueType::U16 => u16(),
+            PrimitiveValueType::S32 => s32(),
+            PrimitiveValueType::U32 => u32(),
+            PrimitiveValueType::S64 => s64(),
+            PrimitiveValueType::U64 => u64(),
+            PrimitiveValueType::F32 => f32(),
+            PrimitiveValueType::F64 => f64(),
+            PrimitiveValueType::Chr => chr(),
+            PrimitiveValueType::Str => str(),
         }
     }
 }

--- a/src/analysis/model.rs
+++ b/src/analysis/model.rs
@@ -281,6 +281,138 @@ pub enum AnalysedType {
     Handle(TypeHandle),
 }
 
+impl AnalysedType {
+    pub fn field(name: &str, typ: AnalysedType) -> NameTypePair {
+        NameTypePair {
+            name: name.to_string(),
+            typ,
+        }
+    }
+
+    pub fn case(name: &str, typ: AnalysedType) -> NameOptionTypePair {
+        NameOptionTypePair {
+            name: name.to_string(),
+            typ: Some(typ),
+        }
+    }
+
+    pub fn unit_case(name: &str) -> NameOptionTypePair {
+        NameOptionTypePair {
+            name: name.to_string(),
+            typ: None,
+        }
+    }
+
+    pub fn bool() -> AnalysedType {
+        AnalysedType::Bool(TypeBool)
+    }
+
+    pub fn s8() -> AnalysedType {
+        AnalysedType::S8(TypeS8)
+    }
+
+    pub fn s16() -> AnalysedType {
+        AnalysedType::S16(TypeS16)
+    }
+
+    pub fn s32() -> AnalysedType {
+        AnalysedType::S32(TypeS32)
+    }
+
+    pub fn s64() -> AnalysedType {
+        AnalysedType::S64(TypeS64)
+    }
+
+    pub fn u8() -> AnalysedType {
+        AnalysedType::U8(TypeU8)
+    }
+
+    pub fn u16() -> AnalysedType {
+        AnalysedType::U16(TypeU16)
+    }
+
+    pub fn u32() -> AnalysedType {
+        AnalysedType::U32(TypeU32)
+    }
+
+    pub fn u64() -> AnalysedType {
+        AnalysedType::U64(TypeU64)
+    }
+
+    pub fn f32() -> AnalysedType {
+        AnalysedType::F32(TypeF32)
+    }
+
+    pub fn f64() -> AnalysedType {
+        AnalysedType::F64(TypeF64)
+    }
+
+    pub fn chr() -> AnalysedType {
+        AnalysedType::Chr(TypeChr)
+    }
+
+    pub fn str() -> AnalysedType {
+        AnalysedType::Str(TypeStr)
+    }
+
+    pub fn list(inner: AnalysedType) -> AnalysedType {
+        AnalysedType::List(TypeList {
+            inner: Box::new(inner),
+        })
+    }
+
+    pub fn option(inner: AnalysedType) -> AnalysedType {
+        AnalysedType::Option(TypeOption {
+            inner: Box::new(inner),
+        })
+    }
+
+    pub fn flags(names: &[&str]) -> AnalysedType {
+        AnalysedType::Flags(TypeFlags {
+            names: names.iter().map(|n| n.to_string()).collect(),
+        })
+    }
+
+    pub fn r#enum(cases: &[&str]) -> AnalysedType {
+        AnalysedType::Enum(TypeEnum {
+            cases: cases.iter().map(|n| n.to_string()).collect(),
+        })
+    }
+
+    pub fn tuple(items: Vec<AnalysedType>) -> AnalysedType {
+        AnalysedType::Tuple(TypeTuple { items })
+    }
+
+    pub fn result(ok: AnalysedType, err: AnalysedType) -> AnalysedType {
+        AnalysedType::Result(TypeResult {
+            ok: Some(Box::new(ok)),
+            err: Some(Box::new(err)),
+        })
+    }
+
+    pub fn result_ok(ok: AnalysedType) -> AnalysedType {
+        AnalysedType::Result(TypeResult {
+            ok: Some(Box::new(ok)),
+            err: None,
+        })
+    }
+
+    pub fn result_err(err: AnalysedType) -> AnalysedType {
+        AnalysedType::Result(TypeResult {
+            ok: None,
+            err: Some(Box::new(err)),
+        })
+    }
+
+    pub fn record(fields: Vec<NameTypePair>) -> AnalysedType {
+        AnalysedType::Record(TypeRecord { fields })
+    }
+
+    pub fn variant(cases: Vec<NameOptionTypePair>) -> AnalysedType {
+        AnalysedType::Variant(TypeVariant { cases })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
 #[cfg_attr(feature = "json", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]

--- a/tests/exports.rs
+++ b/tests/exports.rs
@@ -1,8 +1,10 @@
+use golem_wasm_ast::analysis::analysed_type::{
+    case, f32, field, handle, list, record, result, result_err, str, tuple, u32, u64, unit_case,
+    variant,
+};
 use golem_wasm_ast::analysis::{
     AnalysedExport, AnalysedFunction, AnalysedFunctionParameter, AnalysedFunctionResult,
-    AnalysedInstance, AnalysedResourceId, AnalysedResourceMode, AnalysedType, AnalysisContext,
-    NameOptionTypePair, NameTypePair, TypeF32, TypeHandle, TypeList, TypeRecord, TypeResult,
-    TypeStr, TypeTuple, TypeU32, TypeU64, TypeVariant,
+    AnalysedInstance, AnalysedResourceId, AnalysedResourceMode, AnalysisContext,
 };
 use golem_wasm_ast::component::Component;
 use golem_wasm_ast::IgnoreAllButMetadata;
@@ -22,7 +24,7 @@ fn exports_shopping_cart_component() {
                 name: "initialize-cart".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "user-id".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![],
             },
@@ -30,26 +32,12 @@ fn exports_shopping_cart_component() {
                 name: "add-item".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "item".to_string(),
-                    typ: AnalysedType::Record(TypeRecord {
-                        fields: vec![
-                            NameTypePair {
-                                name: "product-id".to_string(),
-                                typ: AnalysedType::Str(TypeStr),
-                            },
-                            NameTypePair {
-                                name: "name".to_string(),
-                                typ: AnalysedType::Str(TypeStr),
-                            },
-                            NameTypePair {
-                                name: "price".to_string(),
-                                typ: AnalysedType::F32(TypeF32),
-                            },
-                            NameTypePair {
-                                name: "quantity".to_string(),
-                                typ: AnalysedType::U32(TypeU32),
-                            },
-                        ],
-                    }),
+                    typ: record(vec![
+                        field("product-id", str()),
+                        field("name", str()),
+                        field("price", f32()),
+                        field("quantity", u32()),
+                    ]),
                 }],
                 results: vec![],
             },
@@ -57,7 +45,7 @@ fn exports_shopping_cart_component() {
                 name: "remove-item".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "product-id".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![],
             },
@@ -66,11 +54,11 @@ fn exports_shopping_cart_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "product-id".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                     AnalysedFunctionParameter {
                         name: "quantity".to_string(),
-                        typ: AnalysedType::U32(TypeU32),
+                        typ: u32(),
                     },
                 ],
                 results: vec![],
@@ -80,23 +68,10 @@ fn exports_shopping_cart_component() {
                 parameters: vec![],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Variant(TypeVariant {
-                        cases: vec![
-                            NameOptionTypePair {
-                                name: "error".to_string(),
-                                typ: Some(AnalysedType::Str(TypeStr)),
-                            },
-                            NameOptionTypePair {
-                                name: "success".to_string(),
-                                typ: Some(AnalysedType::Record(TypeRecord {
-                                    fields: vec![NameTypePair {
-                                        name: "order-id".to_string(),
-                                        typ: AnalysedType::Str(TypeStr),
-                                    }],
-                                })),
-                            },
-                        ],
-                    }),
+                    typ: variant(vec![
+                        case("error", str()),
+                        case("success", record(vec![field("order-id", str())])),
+                    ]),
                 }],
             },
             AnalysedFunction {
@@ -104,28 +79,12 @@ fn exports_shopping_cart_component() {
                 parameters: vec![],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::List(TypeList {
-                        inner: Box::new(AnalysedType::Record(TypeRecord {
-                            fields: vec![
-                                NameTypePair {
-                                    name: "product-id".to_string(),
-                                    typ: AnalysedType::Str(TypeStr),
-                                },
-                                NameTypePair {
-                                    name: "name".to_string(),
-                                    typ: AnalysedType::Str(TypeStr),
-                                },
-                                NameTypePair {
-                                    name: "price".to_string(),
-                                    typ: AnalysedType::F32(TypeF32),
-                                },
-                                NameTypePair {
-                                    name: "quantity".to_string(),
-                                    typ: AnalysedType::U32(TypeU32),
-                                },
-                            ],
-                        })),
-                    }),
+                    typ: list(record(vec![
+                        field("product-id", str()),
+                        field("name", str()),
+                        field("price", f32()),
+                        field("quantity", u32()),
+                    ])),
                 }],
             },
         ],
@@ -149,14 +108,11 @@ fn exports_file_service_component() {
                 name: "read-file".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "path".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: Some(Box::new(AnalysedType::Str(TypeStr))),
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result(str(), str()),
                 }],
             },
             AnalysedFunction {
@@ -164,19 +120,16 @@ fn exports_file_service_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "path".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                     AnalysedFunctionParameter {
                         name: "contents".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                 ],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: None,
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result_err(str()),
                 }],
             },
             AnalysedFunction {
@@ -184,141 +137,84 @@ fn exports_file_service_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "path".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                     AnalysedFunctionParameter {
                         name: "contents".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                 ],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: None,
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result_err(str()),
                 }],
             },
             AnalysedFunction {
                 name: "delete-file".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "path".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: None,
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result_err(str()),
                 }],
             },
             AnalysedFunction {
                 name: "get-file-info".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "path".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: Some(Box::new(AnalysedType::Record(TypeRecord {
-                            fields: vec![
-                                NameTypePair {
-                                    name: "last-modified".to_string(),
-                                    typ: AnalysedType::Record(TypeRecord {
-                                        fields: vec![
-                                            NameTypePair {
-                                                name: "seconds".to_string(),
-                                                typ: AnalysedType::U64(TypeU64),
-                                            },
-                                            NameTypePair {
-                                                name: "nanoseconds".to_string(),
-                                                typ: AnalysedType::U32(TypeU32),
-                                            },
-                                        ],
-                                    }),
-                                },
-                                NameTypePair {
-                                    name: "last-accessed".to_string(),
-                                    typ: AnalysedType::Record(TypeRecord {
-                                        fields: vec![
-                                            NameTypePair {
-                                                name: "seconds".to_string(),
-                                                typ: AnalysedType::U64(TypeU64),
-                                            },
-                                            NameTypePair {
-                                                name: "nanoseconds".to_string(),
-                                                typ: AnalysedType::U32(TypeU32),
-                                            },
-                                        ],
-                                    }),
-                                },
-                            ],
-                        }))),
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result(
+                        record(vec![
+                            field(
+                                "last-modified",
+                                record(vec![field("seconds", u64()), field("nanoseconds", u32())]),
+                            ),
+                            field(
+                                "last-accessed",
+                                record(vec![field("seconds", u64()), field("nanoseconds", u32())]),
+                            ),
+                        ]),
+                        str(),
+                    ),
                 }],
             },
             AnalysedFunction {
                 name: "get-info".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "path".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: Some(Box::new(AnalysedType::Record(TypeRecord {
-                            fields: vec![
-                                NameTypePair {
-                                    name: "last-modified".to_string(),
-                                    typ: AnalysedType::Record(TypeRecord {
-                                        fields: vec![
-                                            NameTypePair {
-                                                name: "seconds".to_string(),
-                                                typ: AnalysedType::U64(TypeU64),
-                                            },
-                                            NameTypePair {
-                                                name: "nanoseconds".to_string(),
-                                                typ: AnalysedType::U32(TypeU32),
-                                            },
-                                        ],
-                                    }),
-                                },
-                                NameTypePair {
-                                    name: "last-accessed".to_string(),
-                                    typ: AnalysedType::Record(TypeRecord {
-                                        fields: vec![
-                                            NameTypePair {
-                                                name: "seconds".to_string(),
-                                                typ: AnalysedType::U64(TypeU64),
-                                            },
-                                            NameTypePair {
-                                                name: "nanoseconds".to_string(),
-                                                typ: AnalysedType::U32(TypeU32),
-                                            },
-                                        ],
-                                    }),
-                                },
-                            ],
-                        }))),
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result(
+                        record(vec![
+                            field(
+                                "last-modified",
+                                record(vec![field("seconds", u64()), field("nanoseconds", u32())]),
+                            ),
+                            field(
+                                "last-accessed",
+                                record(vec![field("seconds", u64()), field("nanoseconds", u32())]),
+                            ),
+                        ]),
+                        str(),
+                    ),
                 }],
             },
             AnalysedFunction {
                 name: "create-directory".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "path".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: None,
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result_err(str()),
                 }],
             },
             AnalysedFunction {
@@ -326,19 +222,16 @@ fn exports_file_service_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "source".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                     AnalysedFunctionParameter {
                         name: "destination".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                 ],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: None,
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result_err(str()),
                 }],
             },
             AnalysedFunction {
@@ -346,47 +239,38 @@ fn exports_file_service_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "source".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                     AnalysedFunctionParameter {
                         name: "destination".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                 ],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: None,
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result_err(str()),
                 }],
             },
             AnalysedFunction {
                 name: "remove-directory".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "path".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: None,
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result_err(str()),
                 }],
             },
             AnalysedFunction {
                 name: "remove-file".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "path".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: None,
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result_err(str()),
                 }],
             },
             AnalysedFunction {
@@ -394,44 +278,30 @@ fn exports_file_service_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "source".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                     AnalysedFunctionParameter {
                         name: "destination".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                 ],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: None,
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result_err(str()),
                 }],
             },
             AnalysedFunction {
                 name: "hash".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "path".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Result(TypeResult {
-                        ok: Some(Box::new(AnalysedType::Record(TypeRecord {
-                            fields: vec![
-                                NameTypePair {
-                                    name: "lower".to_string(),
-                                    typ: AnalysedType::U64(TypeU64),
-                                },
-                                NameTypePair {
-                                    name: "upper".to_string(),
-                                    typ: AnalysedType::U64(TypeU64),
-                                },
-                            ],
-                        }))),
-                        err: Some(Box::new(AnalysedType::Str(TypeStr))),
-                    }),
+                    typ: result(
+                        record(vec![field("lower", u64()), field("upper", u64())]),
+                        str(),
+                    ),
                 }],
             },
         ],
@@ -461,23 +331,16 @@ fn exports_auction_registry_composed_component() {
                     parameters: vec![
                         AnalysedFunctionParameter {
                             name: "name".to_string(),
-                            typ: AnalysedType::Str(TypeStr),
+                            typ: str(),
                         },
                         AnalysedFunctionParameter {
                             name: "address".to_string(),
-                            typ: AnalysedType::Str(TypeStr),
+                            typ: str(),
                         },
                     ],
                     results: vec![AnalysedFunctionResult {
                         name: None,
-                        typ: AnalysedType::Record(TypeRecord {
-                            fields: vec![
-                                (NameTypePair {
-                                    name: "bidder-id".to_string(),
-                                    typ: AnalysedType::Str(TypeStr)
-                                })
-                            ]
-                        }),
+                        typ: record(vec![field("bidder-id", str())]),
                     }],
                 },
                 AnalysedFunction {
@@ -485,29 +348,24 @@ fn exports_auction_registry_composed_component() {
                     parameters: vec![
                         AnalysedFunctionParameter {
                             name: "name".to_string(),
-                            typ: AnalysedType::Str(TypeStr),
+                            typ: str(),
                         },
                         AnalysedFunctionParameter {
                             name: "description".to_string(),
-                            typ: AnalysedType::Str(TypeStr),
+                            typ: str(),
                         },
                         AnalysedFunctionParameter {
                             name: "limit-price".to_string(),
-                            typ: AnalysedType::F32(TypeF32),
+                            typ: f32(),
                         },
                         AnalysedFunctionParameter {
                             name: "expiration".to_string(),
-                            typ: AnalysedType::U64(TypeU64),
+                            typ: u64(),
                         },
                     ],
                     results: vec![AnalysedFunctionResult {
                         name: None,
-                        typ: AnalysedType::Record(TypeRecord {
-                            fields: vec![NameTypePair {
-                                name: "auction-id".to_string(),
-                                typ: AnalysedType::Str(TypeStr),
-                            }]
-                        }),
+                        typ: record(vec![field("auction-id", str())]),
                     }],
                 },
                 AnalysedFunction {
@@ -515,37 +373,13 @@ fn exports_auction_registry_composed_component() {
                     parameters: vec![],
                     results: vec![AnalysedFunctionResult {
                         name: None,
-                        typ: AnalysedType::List(TypeList {
-                            inner: Box::new(AnalysedType::Record(TypeRecord {
-                                fields: vec![
-                                    NameTypePair {
-                                        name: "auction-id".to_string(),
-                                        typ: AnalysedType::Record(TypeRecord {
-                                            fields: vec![NameTypePair {
-                                                name: "auction-id".to_string(),
-                                                typ: AnalysedType::Str(TypeStr),
-                                            }]
-                                        }),
-                                    },
-                                    NameTypePair {
-                                        name: "name".to_string(),
-                                        typ: AnalysedType::Str(TypeStr),
-                                    },
-                                    NameTypePair {
-                                        name: "description".to_string(),
-                                        typ: AnalysedType::Str(TypeStr),
-                                    },
-                                    NameTypePair {
-                                        name: "limit-price".to_string(),
-                                        typ: AnalysedType::F32(TypeF32),
-                                    },
-                                    NameTypePair {
-                                        name: "expiration".to_string(),
-                                        typ: AnalysedType::U64(TypeU64),
-                                    },
-                                ],
-                            }))
-                        }),
+                        typ: list(record(vec![
+                            field("auction-id", record(vec![field("auction-id", str())])),
+                            field("name", str()),
+                            field("description", str()),
+                            field("limit-price", f32()),
+                            field("expiration", u64()),
+                        ],))
                     }],
                 },
             ],
@@ -568,14 +402,11 @@ fn exports_shopping_cart_resource_component() {
                 name: "[constructor]cart".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "user-id".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Handle(TypeHandle {
-                        resource_id: AnalysedResourceId(0),
-                        mode: AnalysedResourceMode::Owned,
-                    }),
+                    typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Owned),
                 }],
             },
             AnalysedFunction {
@@ -583,33 +414,16 @@ fn exports_shopping_cart_resource_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "self".to_string(),
-                        typ: AnalysedType::Handle(TypeHandle {
-                            resource_id: AnalysedResourceId(0),
-                            mode: AnalysedResourceMode::Borrowed,
-                        }),
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                     },
                     AnalysedFunctionParameter {
                         name: "item".to_string(),
-                        typ: AnalysedType::Record(TypeRecord {
-                            fields: vec![
-                                NameTypePair {
-                                    name: "product-id".to_string(),
-                                    typ: AnalysedType::Str(TypeStr),
-                                },
-                                NameTypePair {
-                                    name: "name".to_string(),
-                                    typ: AnalysedType::Str(TypeStr),
-                                },
-                                NameTypePair {
-                                    name: "price".to_string(),
-                                    typ: AnalysedType::F32(TypeF32),
-                                },
-                                NameTypePair {
-                                    name: "quantity".to_string(),
-                                    typ: AnalysedType::U32(TypeU32),
-                                },
-                            ],
-                        }),
+                        typ: record(vec![
+                            field("product-id", str()),
+                            field("name", str()),
+                            field("price", f32()),
+                            field("quantity", u32()),
+                        ]),
                     },
                 ],
                 results: vec![],
@@ -619,14 +433,11 @@ fn exports_shopping_cart_resource_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "self".to_string(),
-                        typ: AnalysedType::Handle(TypeHandle {
-                            resource_id: AnalysedResourceId(0),
-                            mode: AnalysedResourceMode::Borrowed,
-                        }),
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                     },
                     AnalysedFunctionParameter {
                         name: "product-id".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                 ],
                 results: vec![],
@@ -636,18 +447,15 @@ fn exports_shopping_cart_resource_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "self".to_string(),
-                        typ: AnalysedType::Handle(TypeHandle {
-                            resource_id: AnalysedResourceId(0),
-                            mode: AnalysedResourceMode::Borrowed,
-                        }),
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                     },
                     AnalysedFunctionParameter {
                         name: "product-id".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                     AnalysedFunctionParameter {
                         name: "quantity".to_string(),
-                        typ: AnalysedType::U32(TypeU32),
+                        typ: u32(),
                     },
                 ],
                 results: vec![],
@@ -656,65 +464,30 @@ fn exports_shopping_cart_resource_component() {
                 name: "[method]cart.checkout".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "self".to_string(),
-                    typ: AnalysedType::Handle(TypeHandle {
-                        resource_id: AnalysedResourceId(0),
-                        mode: AnalysedResourceMode::Borrowed,
-                    }),
+                    typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Variant(TypeVariant {
-                        cases: vec![
-                            NameOptionTypePair {
-                                name: "error".to_string(),
-                                typ: Some(AnalysedType::Str(TypeStr)),
-                            },
-                            NameOptionTypePair {
-                                name: "success".to_string(),
-                                typ: Some(AnalysedType::Record(TypeRecord {
-                                    fields: vec![NameTypePair {
-                                        name: "order-id".to_string(),
-                                        typ: AnalysedType::Str(TypeStr),
-                                    }],
-                                })),
-                            },
-                        ],
-                    }),
+                    typ: variant(vec![
+                        case("error", str()),
+                        case("success", record(vec![field("order-id", str())])),
+                    ]),
                 }],
             },
             AnalysedFunction {
                 name: "[method]cart.get-cart-contents".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "self".to_string(),
-                    typ: AnalysedType::Handle(TypeHandle {
-                        resource_id: AnalysedResourceId(0),
-                        mode: AnalysedResourceMode::Borrowed,
-                    }),
+                    typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::List(TypeList {
-                        inner: Box::new(AnalysedType::Record(TypeRecord {
-                            fields: vec![
-                                NameTypePair {
-                                    name: "product-id".to_string(),
-                                    typ: AnalysedType::Str(TypeStr),
-                                },
-                                NameTypePair {
-                                    name: "name".to_string(),
-                                    typ: AnalysedType::Str(TypeStr),
-                                },
-                                NameTypePair {
-                                    name: "price".to_string(),
-                                    typ: AnalysedType::F32(TypeF32),
-                                },
-                                NameTypePair {
-                                    name: "quantity".to_string(),
-                                    typ: AnalysedType::U32(TypeU32),
-                                },
-                            ],
-                        })),
-                    }),
+                    typ: list(record(vec![
+                        field("product-id", str()),
+                        field("name", str()),
+                        field("price", f32()),
+                        field("quantity", u32()),
+                    ])),
                 }],
             },
             AnalysedFunction {
@@ -722,17 +495,11 @@ fn exports_shopping_cart_resource_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "self".to_string(),
-                        typ: AnalysedType::Handle(TypeHandle {
-                            resource_id: AnalysedResourceId(0),
-                            mode: AnalysedResourceMode::Borrowed,
-                        }),
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                     },
                     AnalysedFunctionParameter {
                         name: "other-cart".to_string(),
-                        typ: AnalysedType::Handle(TypeHandle {
-                            resource_id: AnalysedResourceId(0),
-                            mode: AnalysedResourceMode::Borrowed,
-                        }),
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                     },
                 ],
                 results: vec![],
@@ -758,14 +525,11 @@ fn exports_shopping_cart_resource_versioned_component() {
                 name: "[constructor]cart".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "user-id".to_string(),
-                    typ: AnalysedType::Str(TypeStr),
+                    typ: str(),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Handle(TypeHandle {
-                        resource_id: AnalysedResourceId(0),
-                        mode: AnalysedResourceMode::Owned,
-                    }),
+                    typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Owned),
                 }],
             },
             AnalysedFunction {
@@ -773,33 +537,16 @@ fn exports_shopping_cart_resource_versioned_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "self".to_string(),
-                        typ: AnalysedType::Handle(TypeHandle {
-                            resource_id: AnalysedResourceId(0),
-                            mode: AnalysedResourceMode::Borrowed,
-                        }),
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                     },
                     AnalysedFunctionParameter {
                         name: "item".to_string(),
-                        typ: AnalysedType::Record(TypeRecord {
-                            fields: vec![
-                                NameTypePair {
-                                    name: "product-id".to_string(),
-                                    typ: AnalysedType::Str(TypeStr),
-                                },
-                                NameTypePair {
-                                    name: "name".to_string(),
-                                    typ: AnalysedType::Str(TypeStr),
-                                },
-                                NameTypePair {
-                                    name: "price".to_string(),
-                                    typ: AnalysedType::F32(TypeF32),
-                                },
-                                NameTypePair {
-                                    name: "quantity".to_string(),
-                                    typ: AnalysedType::U32(TypeU32),
-                                },
-                            ],
-                        }),
+                        typ: record(vec![
+                            field("product-id", str()),
+                            field("name", str()),
+                            field("price", f32()),
+                            field("quantity", u32()),
+                        ]),
                     },
                 ],
                 results: vec![],
@@ -809,14 +556,11 @@ fn exports_shopping_cart_resource_versioned_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "self".to_string(),
-                        typ: AnalysedType::Handle(TypeHandle {
-                            resource_id: AnalysedResourceId(0),
-                            mode: AnalysedResourceMode::Borrowed,
-                        }),
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                     },
                     AnalysedFunctionParameter {
                         name: "product-id".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                 ],
                 results: vec![],
@@ -826,18 +570,15 @@ fn exports_shopping_cart_resource_versioned_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "self".to_string(),
-                        typ: AnalysedType::Handle(TypeHandle {
-                            resource_id: AnalysedResourceId(0),
-                            mode: AnalysedResourceMode::Borrowed,
-                        }),
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                     },
                     AnalysedFunctionParameter {
                         name: "product-id".to_string(),
-                        typ: AnalysedType::Str(TypeStr),
+                        typ: str(),
                     },
                     AnalysedFunctionParameter {
                         name: "quantity".to_string(),
-                        typ: AnalysedType::U32(TypeU32),
+                        typ: u32(),
                     },
                 ],
                 results: vec![],
@@ -846,65 +587,30 @@ fn exports_shopping_cart_resource_versioned_component() {
                 name: "[method]cart.checkout".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "self".to_string(),
-                    typ: AnalysedType::Handle(TypeHandle {
-                        resource_id: AnalysedResourceId(0),
-                        mode: AnalysedResourceMode::Borrowed,
-                    }),
+                    typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::Variant(TypeVariant {
-                        cases: vec![
-                            NameOptionTypePair {
-                                name: "error".to_string(),
-                                typ: Some(AnalysedType::Str(TypeStr)),
-                            },
-                            NameOptionTypePair {
-                                name: "success".to_string(),
-                                typ: Some(AnalysedType::Record(TypeRecord {
-                                    fields: vec![NameTypePair {
-                                        name: "order-id".to_string(),
-                                        typ: AnalysedType::Str(TypeStr),
-                                    }],
-                                })),
-                            },
-                        ],
-                    }),
+                    typ: variant(vec![
+                        case("error", str()),
+                        case("success", record(vec![field("order-id", str())])),
+                    ]),
                 }],
             },
             AnalysedFunction {
                 name: "[method]cart.get-cart-contents".to_string(),
                 parameters: vec![AnalysedFunctionParameter {
                     name: "self".to_string(),
-                    typ: AnalysedType::Handle(TypeHandle {
-                        resource_id: AnalysedResourceId(0),
-                        mode: AnalysedResourceMode::Borrowed,
-                    }),
+                    typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                 }],
                 results: vec![AnalysedFunctionResult {
                     name: None,
-                    typ: AnalysedType::List(TypeList {
-                        inner: Box::new(AnalysedType::Record(TypeRecord {
-                            fields: vec![
-                                NameTypePair {
-                                    name: "product-id".to_string(),
-                                    typ: AnalysedType::Str(TypeStr),
-                                },
-                                NameTypePair {
-                                    name: "name".to_string(),
-                                    typ: AnalysedType::Str(TypeStr),
-                                },
-                                NameTypePair {
-                                    name: "price".to_string(),
-                                    typ: AnalysedType::F32(TypeF32),
-                                },
-                                NameTypePair {
-                                    name: "quantity".to_string(),
-                                    typ: AnalysedType::U32(TypeU32),
-                                },
-                            ],
-                        })),
-                    }),
+                    typ: list(record(vec![
+                        field("product-id", str()),
+                        field("name", str()),
+                        field("price", f32()),
+                        field("quantity", u32()),
+                    ])),
                 }],
             },
             AnalysedFunction {
@@ -912,17 +618,11 @@ fn exports_shopping_cart_resource_versioned_component() {
                 parameters: vec![
                     AnalysedFunctionParameter {
                         name: "self".to_string(),
-                        typ: AnalysedType::Handle(TypeHandle {
-                            resource_id: AnalysedResourceId(0),
-                            mode: AnalysedResourceMode::Borrowed,
-                        }),
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                     },
                     AnalysedFunctionParameter {
                         name: "other-cart".to_string(),
-                        typ: AnalysedType::Handle(TypeHandle {
-                            resource_id: AnalysedResourceId(0),
-                            mode: AnalysedResourceMode::Borrowed,
-                        }),
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
                     },
                 ],
                 results: vec![],
@@ -947,11 +647,7 @@ fn exports_caller_composed_component() {
             parameters: vec![],
             results: vec![AnalysedFunctionResult {
                 name: None,
-                typ: AnalysedType::List(TypeList {
-                    inner: Box::new(AnalysedType::Tuple(TypeTuple {
-                        items: vec![AnalysedType::Str(TypeStr), AnalysedType::U64(TypeU64)],
-                    })),
-                }),
+                typ: list(tuple(vec![str(), u64()])),
             }],
         }),
         AnalysedExport::Function(AnalysedFunction {
@@ -959,7 +655,7 @@ fn exports_caller_composed_component() {
             parameters: vec![],
             results: vec![AnalysedFunctionResult {
                 name: None,
-                typ: AnalysedType::U64(TypeU64),
+                typ: u64(),
             }],
         }),
         AnalysedExport::Function(AnalysedFunction {
@@ -967,7 +663,7 @@ fn exports_caller_composed_component() {
             parameters: vec![],
             results: vec![AnalysedFunctionResult {
                 name: None,
-                typ: AnalysedType::U64(TypeU64),
+                typ: u64(),
             }],
         }),
         AnalysedExport::Function(AnalysedFunction {
@@ -975,18 +671,7 @@ fn exports_caller_composed_component() {
             parameters: vec![],
             results: vec![AnalysedFunctionResult {
                 name: None,
-                typ: AnalysedType::Tuple(TypeTuple {
-                    items: vec![
-                        AnalysedType::List(TypeList {
-                            inner: Box::new(AnalysedType::Str(TypeStr)),
-                        }),
-                        AnalysedType::List(TypeList {
-                            inner: Box::new(AnalysedType::Tuple(TypeTuple {
-                                items: vec![AnalysedType::Str(TypeStr), AnalysedType::Str(TypeStr)],
-                            })),
-                        }),
-                    ],
-                }),
+                typ: tuple(vec![list(str()), list(tuple(vec![str(), str()]))]),
             }],
         }),
         AnalysedExport::Function(AnalysedFunction {
@@ -994,30 +679,18 @@ fn exports_caller_composed_component() {
             parameters: vec![],
             results: vec![AnalysedFunctionResult {
                 name: None,
-                typ: AnalysedType::List(TypeList {
-                    inner: Box::new(AnalysedType::U64(TypeU64)),
-                }),
+                typ: list(u64()),
             }],
         }),
         AnalysedExport::Function(AnalysedFunction {
             name: "bug-wasm-rpc-i32".to_string(),
             parameters: vec![AnalysedFunctionParameter {
                 name: "in".to_string(),
-                typ: AnalysedType::Variant(TypeVariant {
-                    cases: vec![NameOptionTypePair {
-                        name: "leaf".to_string(),
-                        typ: None,
-                    }],
-                }),
+                typ: variant(vec![unit_case("leaf")]),
             }],
             results: vec![AnalysedFunctionResult {
                 name: None,
-                typ: AnalysedType::Variant(TypeVariant {
-                    cases: vec![NameOptionTypePair {
-                        name: "leaf".to_string(),
-                        typ: None,
-                    }],
-                }),
+                typ: variant(vec![unit_case("leaf")]),
             }],
         }),
     ];


### PR DESCRIPTION
These were already defined and used here:
https://github.com/golemcloud/wasm-rpc/blob/main/wasm-rpc-stubgen/tests/stub_wasm.rs

Moving them to `AnalysedType` makes it possible to use these anywhere by importing `analysed_type::*` (for example in tests, or when dynamically generating types)

Resolves https://github.com/golemcloud/wasm-rpc/issues/86
Related to https://github.com/golemcloud/golem/issues/917